### PR TITLE
Validation of configuration file

### DIFF
--- a/stools/configuration.configspec
+++ b/stools/configuration.configspec
@@ -1,0 +1,14 @@
+[machines]
+
+    [[__many__]]
+
+    ip = string()
+    username = string()
+    password = string()
+
+[tasks]
+
+    [[__many__]]
+    
+        [[[__many__]]]
+        type = option(copy, recovery, command, default="command")


### PR DESCRIPTION
Fixes #1 

Creation of **configuration.configspec** file for validate any configuration files.
In **Configuration** class for all construction of **ConfigObj** object, we now validate the configuration file before.
If any syntax error can be found in file, we print it and stop all execution.
